### PR TITLE
feat: Add web scraper for live price comparison

### DIFF
--- a/app/(app)/products/[id]/page.tsx
+++ b/app/(app)/products/[id]/page.tsx
@@ -4,33 +4,124 @@ import { db } from "@/lib/db";
 import { suppliers, sourceProducts, scrapedOffers } from "@/lib/db/schema";
 import { desc, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { scrapeProductPage } from "@/lib/scraper";
 import {
   Card,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { ScrapeButton } from "@/components/scrape-button";
+import { AddSourceForm } from "@/components/add-source-form";
+import { RescrapeAllButton } from "@/components/rescrape-all-button";
 import {
   ArrowLeft,
   ExternalLink,
-  Sparkles,
   TrendingDown,
   TrendingUp,
   BarChart3,
 } from "lucide-react";
 
-async function seedDummyOffers(formData: FormData) {
+type ScrapeState = { error?: string; success?: boolean } | null;
+type RescrapeState = { error?: string; refreshed?: number } | null;
+
+function getDomain(url: string) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+async function scrapeOffer(
+  _prev: ScrapeState,
+  formData: FormData
+): Promise<ScrapeState> {
   "use server";
-  const id = Number(formData.get("product_id"));
-  await db.insert(scrapedOffers).values([
-    { sourceProductId: id, title: "Offer from Seller A", price: 19.99, currency: "USD", inStock: true },
-    { sourceProductId: id, title: "Offer from Seller B", price: 17.49, currency: "USD", inStock: true },
-    { sourceProductId: id, title: "Offer from Seller C", price: 22.0, currency: "USD", inStock: false },
-  ]);
-  revalidatePath(`/products/${id}`);
+  const productId = Number(formData.get("product_id"));
+  const sourceUrl = String(formData.get("source_url"));
+  try {
+    const result = await scrapeProductPage(sourceUrl);
+    await db.insert(scrapedOffers).values({
+      sourceProductId: productId,
+      sourceUrl,
+      title: result.title,
+      price: result.price,
+      currency: result.currency,
+      inStock: result.inStock,
+    });
+    revalidatePath(`/products/${productId}`);
+    revalidatePath("/dashboard");
+    return { success: true };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Scrape failed" };
+  }
+}
+
+async function scrapeNewSource(
+  _prev: ScrapeState,
+  formData: FormData
+): Promise<ScrapeState> {
+  "use server";
+  const productId = Number(formData.get("product_id"));
+  const competitorUrl = String(formData.get("competitor_url")).trim();
+  if (!competitorUrl) return { error: "URL is required" };
+  try {
+    const result = await scrapeProductPage(competitorUrl);
+    await db.insert(scrapedOffers).values({
+      sourceProductId: productId,
+      sourceUrl: competitorUrl,
+      title: result.title,
+      price: result.price,
+      currency: result.currency,
+      inStock: result.inStock,
+    });
+    revalidatePath(`/products/${productId}`);
+    revalidatePath("/dashboard");
+    return { success: true };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Scrape failed" };
+  }
+}
+
+async function rescrapeAll(
+  _prev: RescrapeState,
+  formData: FormData
+): Promise<RescrapeState> {
+  "use server";
+  const productId = Number(formData.get("product_id"));
+
+  // Collect all distinct sourceUrls tracked for this product
+  const existing = await db
+    .select({ sourceUrl: scrapedOffers.sourceUrl })
+    .from(scrapedOffers)
+    .where(eq(scrapedOffers.sourceProductId, productId));
+
+  const urls = [...new Set(existing.map((o) => o.sourceUrl).filter(Boolean))] as string[];
+  if (urls.length === 0) return { error: "No source URLs to rescrape" };
+
+  const results = await Promise.allSettled(
+    urls.map(async (url) => {
+      const result = await scrapeProductPage(url);
+      await db.insert(scrapedOffers).values({
+        sourceProductId: productId,
+        sourceUrl: url,
+        title: result.title,
+        price: result.price,
+        currency: result.currency,
+        inStock: result.inStock,
+      });
+    })
+  );
+
+  revalidatePath(`/products/${productId}`);
   revalidatePath("/dashboard");
+
+  const succeeded = results.filter((r) => r.status === "fulfilled").length;
+  if (succeeded === 0) return { error: "All sources failed to scrape" };
+  return { refreshed: succeeded };
 }
 
 export default async function ProductDetailPage({
@@ -76,11 +167,16 @@ export default async function ProductDetailPage({
         }
       : null;
 
+  const trackedSourceUrls = [
+    ...new Set(offers.map((o) => o.sourceUrl).filter(Boolean)),
+  ] as string[];
+
   const fmt = (n: number, currency: string) =>
     new Intl.NumberFormat("en-US", { style: "currency", currency }).format(n);
 
   return (
     <div className="flex flex-col gap-8">
+      {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-2">
           <Link
@@ -105,15 +201,23 @@ export default async function ProductDetailPage({
             </a>
           </div>
         </div>
-        <form action={seedDummyOffers}>
-          <input type="hidden" name="product_id" value={productId} />
-          <Button type="submit" variant="outline" size="sm">
-            <Sparkles size={14} className="mr-1.5" />
-            Seed dummy offers
-          </Button>
-        </form>
+        <div className="flex items-start gap-2">
+          {trackedSourceUrls.length > 0 && (
+            <RescrapeAllButton
+              action={rescrapeAll}
+              productId={productId}
+              sourceCount={trackedSourceUrls.length}
+            />
+          )}
+          <ScrapeButton
+            action={scrapeOffer}
+            productId={productId}
+            sourceUrl={product.sourceUrl}
+          />
+        </div>
       </div>
 
+      {/* Price stats */}
       {priceStats && (
         <div className="grid gap-4 sm:grid-cols-3">
           <Card>
@@ -158,16 +262,38 @@ export default async function ProductDetailPage({
         </div>
       )}
 
+      {/* Add competitor source */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Add a competitor source</CardTitle>
+          <CardDescription>
+            Paste a product URL from any other supplier to scrape their price
+            and compare against your current source.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AddSourceForm action={scrapeNewSource} productId={productId} />
+        </CardContent>
+      </Card>
+
+      {/* Offers list */}
       <Card>
         <CardHeader>
           <CardTitle>Offers</CardTitle>
+          {trackedSourceUrls.length > 0 && (
+            <CardDescription>
+              Tracking {trackedSourceUrls.length} source
+              {trackedSourceUrls.length !== 1 ? "s" : ""}:{" "}
+              {trackedSourceUrls.map((u) => getDomain(u)).join(", ")}
+            </CardDescription>
+          )}
         </CardHeader>
         <CardContent>
           {offers.length === 0 ? (
             <p className="text-sm text-foreground/60">
               No offers yet. Click{" "}
-              <span className="font-medium">Seed dummy offers</span> above to
-              add some sample data.
+              <span className="font-medium">Scrape now</span> to pull the live
+              price from the source URL, or add a competitor URL above.
             </p>
           ) : (
             <ul className="divide-y">
@@ -176,22 +302,37 @@ export default async function ProductDetailPage({
                   key={offer.id}
                   className="flex items-center justify-between gap-4 py-3"
                 >
-                  <div>
-                    <p className="text-sm font-medium">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">
                       {offer.title ?? "Untitled offer"}
                     </p>
-                    <p className="text-xs text-foreground/40">
-                      {offer.createdAt
-                        ? new Date(offer.createdAt).toLocaleDateString()
-                        : ""}
-                    </p>
+                    <div className="flex items-center gap-2 mt-0.5">
+                      {offer.sourceUrl && (
+                        <a
+                          href={offer.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-0.5 text-xs text-foreground/40 hover:text-foreground"
+                        >
+                          {getDomain(offer.sourceUrl)}
+                          <ExternalLink size={10} />
+                        </a>
+                      )}
+                      <span className="text-xs text-foreground/30">
+                        {offer.createdAt
+                          ? new Date(offer.createdAt).toLocaleDateString()
+                          : ""}
+                      </span>
+                    </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
-                    {priceStats && offer.inStock && offer.price === priceStats.min && (
-                      <Badge className="bg-green-500 text-white hover:bg-green-600">
-                        Best price
-                      </Badge>
-                    )}
+                    {priceStats &&
+                      offer.inStock &&
+                      offer.price === priceStats.min && (
+                        <Badge className="bg-green-500 text-white hover:bg-green-600">
+                          Best price
+                        </Badge>
+                      )}
                     <Badge variant={offer.inStock ? "default" : "secondary"}>
                       {offer.inStock ? "In stock" : "Out of stock"}
                     </Badge>

--- a/components/add-source-form.tsx
+++ b/components/add-source-form.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useActionState, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loader2, Plus } from "lucide-react";
+
+type AddSourceState = { error?: string; success?: boolean } | null;
+
+export function AddSourceForm({
+  action,
+  productId,
+}: {
+  action: (prev: AddSourceState, formData: FormData) => Promise<AddSourceState>;
+  productId: number;
+}) {
+  const [state, formAction, isPending] = useActionState(action, null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  return (
+    <form
+      ref={formRef}
+      action={async (formData) => {
+        await formAction(formData);
+        formRef.current?.reset();
+      }}
+      className="flex flex-col gap-2"
+    >
+      <input type="hidden" name="product_id" value={productId} />
+      <div className="flex gap-2">
+        <Input
+          name="competitor_url"
+          type="url"
+          placeholder="https://other-supplier.com/product/..."
+          required
+          className="flex-1"
+        />
+        <Button type="submit" size="sm" disabled={isPending}>
+          {isPending ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <Plus size={14} />
+          )}
+          <span className="ml-1.5">{isPending ? "Scraping…" : "Add & scrape"}</span>
+        </Button>
+      </div>
+      {state?.error && (
+        <p className="text-xs text-red-500">{state.error}</p>
+      )}
+      {state?.success && (
+        <p className="text-xs text-green-600">Offer added!</p>
+      )}
+    </form>
+  );
+}

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -8,7 +8,7 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
-  CardTitle,
+  CardTitle
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/rescrape-all-button.tsx
+++ b/components/rescrape-all-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useActionState } from "react";
+import { Button } from "@/components/ui/button";
+import { Loader2, RefreshCw } from "lucide-react";
+
+type RescrapeState = { error?: string; refreshed?: number } | null;
+
+export function RescrapeAllButton({
+  action,
+  productId,
+  sourceCount,
+}: {
+  action: (prev: RescrapeState, formData: FormData) => Promise<RescrapeState>;
+  productId: number;
+  sourceCount: number;
+}) {
+  const [state, formAction, isPending] = useActionState(action, null);
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <form action={formAction}>
+        <input type="hidden" name="product_id" value={productId} />
+        <Button type="submit" variant="outline" size="sm" disabled={isPending}>
+          {isPending ? (
+            <Loader2 size={14} className="mr-1.5 animate-spin" />
+          ) : (
+            <RefreshCw size={14} className="mr-1.5" />
+          )}
+          {isPending ? "Refreshing…" : `Rescrape all (${sourceCount})`}
+        </Button>
+      </form>
+      {state?.error && (
+        <p className="text-xs text-red-500">{state.error}</p>
+      )}
+      {state?.refreshed !== undefined && (
+        <p className="text-xs text-green-600">
+          Refreshed {state.refreshed} source{state.refreshed !== 1 ? "s" : ""}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/scrape-button.tsx
+++ b/components/scrape-button.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useActionState } from "react";
+import { Button } from "@/components/ui/button";
+import { Globe, Loader2 } from "lucide-react";
+
+type ScrapeState = { error?: string; success?: boolean } | null;
+
+export function ScrapeButton({
+  action,
+  productId,
+  sourceUrl,
+}: {
+  action: (prev: ScrapeState, formData: FormData) => Promise<ScrapeState>;
+  productId: number;
+  sourceUrl: string;
+}) {
+  const [state, formAction, isPending] = useActionState(action, null);
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <form action={formAction}>
+        <input type="hidden" name="product_id" value={productId} />
+        <input type="hidden" name="source_url" value={sourceUrl} />
+        <Button type="submit" variant="outline" size="sm" disabled={isPending}>
+          {isPending ? (
+            <Loader2 size={14} className="mr-1.5 animate-spin" />
+          ) : (
+            <Globe size={14} className="mr-1.5" />
+          )}
+          {isPending ? "Scraping…" : "Scrape now"}
+        </Button>
+      </form>
+      {state?.error && (
+        <p className="text-xs text-red-500 max-w-[240px] text-right">
+          {state.error}
+        </p>
+      )}
+      {state?.success && (
+        <p className="text-xs text-green-600">Offer saved!</p>
+      )}
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,14 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@/lib/db";
+import * as authSchema from "@/lib/db/auth-schema";
+import * as appSchema from "@/lib/db/schema";
 
 export const auth = betterAuth({
-  database: drizzleAdapter(db, { provider: "sqlite" }),
+  database: drizzleAdapter(db, {
+    provider: "sqlite",
+    schema: { ...authSchema, ...appSchema },
+  }),
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: false,

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,10 +1,11 @@
 import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 import * as appSchema from "./schema";
+import * as authSchema from "./auth-schema";
 
 const client = createClient({
   url: process.env.DATABASE_URL!,
   authToken: process.env.DATABASE_AUTH_TOKEN,
 });
 
-export const db = drizzle(client, { schema: appSchema });
+export const db = drizzle(client, { schema: { ...appSchema, ...authSchema } });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -43,6 +43,7 @@ export const scrapedOffers = sqliteTable(
     sourceProductId: integer("source_product_id")
       .notNull()
       .references(() => sourceProducts.id, { onDelete: "cascade" }),
+    sourceUrl: text("source_url"),
     title: text("title"),
     price: real("price").notNull(),
     currency: text("currency").notNull().default("USD"),

--- a/lib/scraper.ts
+++ b/lib/scraper.ts
@@ -1,0 +1,162 @@
+import * as cheerio from "cheerio";
+
+export interface ScrapeResult {
+  price: number;
+  currency: string;
+  inStock: boolean;
+  title: string | null;
+}
+
+export async function scrapeProductPage(url: string): Promise<ScrapeResult> {
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      Accept: "text/html,application/xhtml+xml",
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
+
+  const html = await res.text();
+  const $ = cheerio.load(html);
+
+  let price: number | null = null;
+  let currency = "USD";
+  // null = no structured signal found yet; true/false = definitive answer from structured data
+  let stockFromStructuredData: boolean | null = null;
+  let title: string | null = null;
+
+  // --- Title ---
+  title =
+    $('meta[property="og:title"]').attr("content")?.trim() ||
+    $("title").text().trim() ||
+    null;
+
+  // --- JSON-LD structured data (most reliable) ---
+  $('script[type="application/ld+json"]').each((_, el) => {
+    if (price !== null) return;
+    try {
+      const raw = JSON.parse($(el).text());
+      const nodes: unknown[] = Array.isArray(raw) ? raw : [raw];
+      for (const node of nodes) {
+        const obj = node as Record<string, unknown>;
+        const type = obj["@type"];
+        const isProduct =
+          type === "Product" ||
+          (Array.isArray(type) && (type as string[]).includes("Product"));
+        if (!isProduct) continue;
+
+        const offers = obj["offers"] as Record<string, unknown> | undefined;
+        if (!offers) continue;
+
+        const rawPrice = offers["price"] ?? offers["lowPrice"];
+        if (rawPrice !== undefined) {
+          const parsed = parseFloat(String(rawPrice));
+          if (!isNaN(parsed)) price = parsed;
+        }
+
+        const cur = offers["priceCurrency"];
+        if (typeof cur === "string" && cur.length === 3) currency = cur;
+
+        const avail = String(offers["availability"] ?? "").toLowerCase();
+        if (avail) {
+          stockFromStructuredData =
+            !avail.includes("outofstock") && !avail.includes("soldout");
+        }
+        if (price !== null) break;
+      }
+    } catch {
+      // malformed JSON-LD — skip
+    }
+  });
+
+  // --- Open Graph / meta tags ---
+  if (price === null) {
+    const metaPrice =
+      $('meta[property="product:price:amount"]').attr("content") ||
+      $('meta[property="og:price:amount"]').attr("content");
+    if (metaPrice) {
+      const parsed = parseFloat(metaPrice);
+      if (!isNaN(parsed)) price = parsed;
+    }
+    const metaCur =
+      $('meta[property="product:price:currency"]').attr("content") ||
+      $('meta[property="og:price:currency"]').attr("content");
+    if (metaCur && metaCur.length === 3) currency = metaCur;
+  }
+
+  // --- schema.org itemprop (price + availability) ---
+  if (price === null) {
+    const el = $('[itemprop="price"]').first();
+    const raw = el.attr("content") || el.text();
+    if (raw) {
+      const parsed = parseFloat(raw.replace(/[^\d.]/g, ""));
+      if (!isNaN(parsed)) price = parsed;
+    }
+  }
+
+  if (stockFromStructuredData === null) {
+    const availEl = $('[itemprop="availability"]').first();
+    const availHref = availEl.attr("href") || availEl.attr("content") || availEl.text();
+    if (availHref) {
+      const a = availHref.toLowerCase();
+      stockFromStructuredData =
+        !a.includes("outofstock") && !a.includes("soldout");
+    }
+  }
+
+  if (stockFromStructuredData === null) {
+    const metaAvail = $('meta[property="product:availability"]').attr("content");
+    if (metaAvail) {
+      const a = metaAvail.toLowerCase();
+      stockFromStructuredData = a === "instock" || a === "in stock";
+    }
+  }
+
+  // --- CSS heuristic: elements whose class/id contains "price" ---
+  if (price === null) {
+    const priceEls = $(
+      '[class*="price" i],[id*="price" i],[data-price],[data-product-price]'
+    );
+    priceEls.each((_, el) => {
+      if (price !== null) return;
+      const raw =
+        $(el).attr("data-price") ||
+        $(el).attr("data-product-price") ||
+        $(el).text();
+      const match = raw.match(/(\d{1,6}(?:[.,]\d{2,3})*)/);
+      if (match) {
+        const parsed = parseFloat(match[1].replace(",", "."));
+        if (!isNaN(parsed) && parsed > 0) price = parsed;
+      }
+    });
+  }
+
+  if (price === null) {
+    throw new Error(
+      "Could not find a price on this page. The site may require JavaScript rendering or block scrapers."
+    );
+  }
+
+  // --- Stock heuristic: only used when structured data gave no signal ---
+  let inStock = stockFromStructuredData ?? true;
+
+  if (stockFromStructuredData === null) {
+    // Scope to stock/availability-specific elements only, not the full body.
+    // This avoids false negatives from "notify me when out of stock" widgets
+    // or unrelated out-of-stock products elsewhere on the page.
+    const stockEls = $(
+      '[class*="stock" i],[id*="stock" i],[class*="availability" i],[id*="availability" i]'
+    );
+    stockEls.each((_, el) => {
+      const text = $(el).text().toLowerCase();
+      if (text.includes("out of stock") || text.includes("sold out")) {
+        inStock = false;
+      }
+    });
+  }
+
+  return { price, currency, inStock, title: title?.slice(0, 255) ?? null };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-slot": "^1.2.2",
         "better-auth": "^1.2.7",
+        "cheerio": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.43.1",
@@ -4804,6 +4805,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5080,6 +5086,46 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chevrotain": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
@@ -5240,6 +5286,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -5495,6 +5567,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -5674,6 +5797,18 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5681,6 +5816,17 @@
       "devOptional": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6875,6 +7021,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -8023,6 +8209,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8260,6 +8457,51 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -9091,6 +9333,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -10588,6 +10835,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -10719,6 +10974,26 @@
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "auth:generate": "npx @better-auth/cli generate --output lib/db/auth-schema.ts --config lib/auth.ts"
   },
   "dependencies": {
+    "@libsql/client": "^0.14.0",
     "@radix-ui/react-checkbox": "^1.3.1",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.6",
     "@radix-ui/react-slot": "^1.2.2",
-    "@libsql/client": "^0.14.0",
     "better-auth": "^1.2.7",
+    "cheerio": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.43.1",


### PR DESCRIPTION
## Summary
- **Web scraper**: Added a Cheerio-based scraper (`lib/scraper.ts`) that extracts product title, price, currency, and stock status from any product page
- **Competitor tracking**: Users can paste competitor URLs on any product detail page to scrape and compare prices across suppliers
- **Rescrape all**: One-click button to refresh prices from all tracked sources for a product
- **Schema & auth fixes**: Added `sourceUrl` column to `scraped_offers`, wired auth schema into the Drizzle client, and passed full schema to the better-auth adapter

## What changed
- `app/(app)/products/[id]/page.tsx` — Replaced dummy "seed offers" with real scrape actions, add-source form, rescrape-all button, and richer offer list UI showing source domains
- `components/scrape-button.tsx` — Client component for scraping the original source URL
- `components/add-source-form.tsx` — Client component for adding a new competitor URL
- `components/rescrape-all-button.tsx` — Client component to rescrape all tracked sources
- `lib/scraper.ts` — Cheerio-based scraper with JSON-LD, Open Graph, and meta tag fallbacks
- `lib/db/schema.ts` — Added `sourceUrl` column to `scrapedOffers`
- `lib/db/index.ts` — Included `authSchema` in the Drizzle client
- `lib/auth.ts` — Passed full schema to the drizzle adapter
- `package.json` — Added `cheerio` dependency

## Test plan
- [ ] Run `npm run build` to verify no type/build errors
- [ ] Open a product detail page and click "Scrape now" to pull live price
- [ ] Add a competitor URL and verify a new offer row appears
- [ ] Click "Rescrape all" and confirm all tracked sources refresh
- [ ] Verify auth (sign-up/login) still works after schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)